### PR TITLE
Bump elixir to 1.3

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Canada.Mixfile do
   def project do
     [app: :canada,
      version: "1.0.0",
-     elixir: "~> 1.0",
+     elixir: "~> 1.3",
      package: package,
      consolidate_protocols: Mix.env != :test,
      description: """


### PR DESCRIPTION
Elixir 1.3 is out and everyone wants to use it \o/.

Also, `mix` warnings suck 😢.

But we can fix this! With this PR! \o/.