### PR TITLE
Add README to project documentation

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,8 @@ defmodule Canada.Mixfile do
      description: """
        A DSL for declarative permissions
      """,
-     deps: deps]
+     deps: deps,
+     docs: docs]
   end
 
   def package do
@@ -25,5 +26,9 @@ defmodule Canada.Mixfile do
 
   defp deps do
     [{:ex_doc, ">= 0.0.0", only: :dev}]
+  end
+
+  defp docs do
+    [extras: ["README.md"]]
   end
 end


### PR DESCRIPTION
This only adds the `README.md` file as an extras to the generated
documentation to be hosted on [hexdocs][1], however, can be quite easily
extended with `:filelib.fold_files/5`.

[1]: https://hexdocs.pm/canada