### PR TITLE
Fix version typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Canada: _Define you some permissions_
 =====================================
 
 **NOTE:** If you're concerned by the fact that this repository has no activity
-lately and hasn't had a release since `v1.0.0`, don't be. The functionality
+lately and hasn't had a release since `v1.0.1`, don't be. The functionality
 this package provides is very simple, it has no dependencies, and the Elixir
 language hasn't changed in any way that would break it. It still works just as
 well as when I first wrote it. :smiley:
@@ -22,7 +22,7 @@ Add it to your deps list in your `mix.exs`. You want the latest release?
 
 ```elixir
 defp deps do
-  [{:canada, "~> 1.0.0"}]
+  [{:canada, "~> 1.0.1"}]
 end
 ```
 


### PR DESCRIPTION
Just a quick PR to fix a very minor typo in the README, so that people who don't read very far don't pull in an older version of canada.