### PR TITLE
fixes compilation warnings in elixir 1.4

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,13 +5,13 @@ defmodule Canada.Mixfile do
     [app: :canada,
      version: "1.0.1",
      elixir: "~> 1.0",
-     package: package,
+     package: package(),
      consolidate_protocols: Mix.env != :test,
      description: """
        A DSL for declarative permissions
      """,
-     deps: deps,
-     docs: docs]
+     deps: deps(),
+     docs: docs()]
   end
 
   def package do


### PR DESCRIPTION
Hi, 
  I've made every function call explicit in mix.exs in order to remove compilation warnings in Elixir 1.4