### PR TITLE
Add @fallback_to_any to handle unexpected types

### DIFF
--- a/lib/canada/can.ex
+++ b/lib/canada/can.ex
@@ -1,4 +1,6 @@
 defprotocol Canada.Can do
+  @fallback_to_any true
+
   @doc "Evaluates permissions"
   def can?(subject, action, resource)
 end

--- a/test/canada_test.exs
+++ b/test/canada_test.exs
@@ -16,6 +16,10 @@ defimpl Canada.Can, for: User do
   def can?(%User{verified: verified}, :create, Post), do: verified
 end
 
+defimpl Canada.Can, for: Any do
+  def can?(_subject, _action, _resource), do: false
+end
+
 defmodule CanadaTest do
   use ExUnit.Case
   import Canada, only: [can?: 2]
@@ -54,5 +58,13 @@ defmodule CanadaTest do
     assert admin_user() |> can?(create(Post))
     assert user() |> can?(create(Post))
     refute other_user() |> can?(create(Post))
+  end
+
+  describe "authorizing 'Any' other resource" do
+    test "accepts any other resource" do
+      refute nil |> can?(touch(Post))
+      refute "" |> can?(touch(Post))
+      refute %{} |> can?(touch(Post))
+    end
   end
 end


### PR DESCRIPTION
Ran into an issue in a web app I'm developing where users are attempting to visit an authorized page after they've been signed out. In those instances, `can?/1` is given a nil value.

Rather than handling a lone instance of `nil`, I thought it might make sense to handle "Any" type that might be given to `can?/1`.